### PR TITLE
Installation fixes

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,7 @@ magenta=$'\e[1;35m'
 cyan=$'\e[1;36m'
 white=$'\e[0m'
 
-
+tools_dir=$(pwd)
 main () {
   echo -e "${blue}\n############################################## ${yellow}\n- downloading and installing NGM ${blue}\n##############################################${white}"
   wget https://github.com/Cibiv/NextGenMap/tarball/master -O NGM.tar.gz
@@ -18,6 +18,7 @@ main () {
   cd build/
   cmake ..
   make
+  cd $tools_dir
 }
 dirtool=*NextGenMap*
 if [ -d $dirtool ]; then
@@ -25,6 +26,9 @@ if [ -d $dirtool ]; then
 else
   echo -e "${magenta}- Performing installation of dependency (NextGenMap aligner: NGM) ${white}"
   main &>> ./log.out
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} NGM did not install properly ${white}"
+  fi
 fi
 
 
@@ -33,7 +37,7 @@ main () {
   wget https://github.com/samtools/bcftools/releases/download/1.17/bcftools-1.17.tar.bz2 &&
   tar -xvf bcftools-1.17.tar.bz2;  cd bcftools-1.17; make
   rm ../bcftools-1.17.tar.bz2
-  cd ..
+  cd $tools_dir
 }
 dirtool=bcftools-1.17
 if [ -d $dirtool ]; then
@@ -41,6 +45,9 @@ if [ -d $dirtool ]; then
 else
   echo -e "${magenta}- Performing installation of dependency (bcftools) ${white}"
   main &>> ./log.out
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} bcftools did not install properly ${white}"
+  fi
 fi
 
 
@@ -49,7 +56,7 @@ main () {
   wget https://github.com/arq5x/bedtools2/releases/download/v2.29.1/bedtools-2.29.1.tar.gz &&
   tar -zxvf bedtools-2.29.1.tar.gz; cd bedtools2; make
   rm ../bedtools-2.29.1.tar.gz
-  cd ..
+  cd $tools_dir
 }
 dirtool=bedtools2
 if [ -d $dirtool ]; then
@@ -57,6 +64,9 @@ if [ -d $dirtool ]; then
 else
   echo -e "${magenta}- Performing installation of dependency (bedtools) ${white}"
   main &>> ./log.out
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} bedtools did not install properly ${white}"
+  fi
 fi
 
 
@@ -65,7 +75,7 @@ main () {
   wget https://github.com/samtools/samtools/releases/download/1.17/samtools-1.17.tar.bz2 &&
   tar -xvf samtools-1.17.tar.bz2;  cd samtools-1.17; make
   rm ../samtools-1.17.tar.bz2
-  cd ../
+  cd $tools_dir
 }
 dirtool=samtools*
 if [ -d $dirtool ]; then
@@ -73,12 +83,16 @@ if [ -d $dirtool ]; then
 else
   echo -e "${magenta}- Performing installation of dependency (samtools) ${white}"
   main &>> ./log.out
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} samtools did not install properly ${white}"
+  fi
 fi
 
 
 main () {
   echo -e "${blue}\n############################################## ${yellow}\n- downloading PICARD tools ${blue}\n##############################################${white}"
   wget https://github.com/broadinstitute/picard/releases/download/2.25.6/picard.jar
+  cd $tools_dir
 }
 dirtool=picard*
 if [ -f $dirtool ]; then
@@ -86,6 +100,9 @@ if [ -f $dirtool ]; then
 else
   echo -e "${magenta}- Performing installation of dependency (picard tools) ${white}"
   main &>> ./log.out
+  if [ ! -f $dirtool ]; then
+      echo -e "${magenta} PICARD tools did not install properly ${white}"
+  fi
 fi
 
 
@@ -93,6 +110,7 @@ main () {
   echo -e "${blue}\n############################################## \n- installiing java 1.8. ${blue}\n##############################################${white}"
   wget https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u322-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u322b06.tar.gz
   tar -xvf OpenJDK8U-jdk_x64_linux_hotspot_8u322b06.tar.gz; rm *tar.gz
+  cd $tools_dir
 }
 dirtool=jdk*
 if [ -d $dirtool ]; then
@@ -100,26 +118,23 @@ if [ -d $dirtool ]; then
 else
   echo -e "${magenta}- Performing installation of dependency (java 1.8)${white}"
   main &>> ./log.out
-fi
-
-dirtool=R
-if [ -d $dirtool ]; then
-  :
-else
-  mkdir ./R
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} java did not install properly ${white}"
+  fi
 fi
 
 
 main () {
   echo -e "${blue}\n############################################## \n- installiing Emboss ${blue}\n##############################################${white}"
-  wget http://debian.rub.de/ubuntu/pool/universe/e/emboss/emboss_6.6.0.orig.tar.gz
-  gunzip emboss_6.6.0.orig.tar.gz
-  tar xvf emboss_6.6.0.orig.tar
+  wget ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-6.6.0.tar.gz
+  gunzip EMBOSS-6.6.0.tar.gz
+  tar xvf EMBOSS-6.6.0.tar
   cd EMBOSS-6.6.0/
   ./configure
   make
   cd ..
-  rm emboss_6.6.0.orig.tar*
+  rm EMBOSS-6.6.0.tar
+  cd $tools_dir
 }
 dirtool=EMBOSS*
 if [ -d $dirtool ]; then
@@ -127,6 +142,9 @@ if [ -d $dirtool ]; then
 else
   echo -e "${magenta}- Performing installation of dependency (EMBOSS)${white}"
   main &>> ./log.out
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} Emboss did not install properly ${white}"
+  fi
 fi
 
 
@@ -143,30 +161,26 @@ main () {
   make clean
   make
   make install
-  cd ../../
+  cd $tools_dir
 }
-dirtool=EMBOSS*
+dirtool=mafft
 if [ -d $dirtool ]; then
   :
 else
-  echo -e "${magenta}- Performing installation of dependency (EMBOSS)${white}"
+  echo -e "${magenta}- Performing installation of dependency (mafft)${white}"
   main &>> ./log.out
-fi
-
-
-dirtool=R
-if [ -d $dirtool ]; then
-  :
-else
-  mkdir ./R
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} mafft did not install properly ${white}"
+  fi
 fi
 
 
 main () {
   echo -e "${green}\n############################################## \n- downloading GATK \n##############################################${white}"
-wget -O GATK4.2.6.1.zip "https://github.com/broadinstitute/gatk/releases/download/4.2.6.1/gatk-4.2.6.1.zip"
-unzip GATK4.2.6.1.zip
-rm GATK4.2.6.1.zip
+  wget -O GATK4.2.6.1.zip "https://github.com/broadinstitute/gatk/releases/download/4.2.6.1/gatk-4.2.6.1.zip"
+  unzip GATK4.2.6.1.zip
+  rm GATK4.2.6.1.zip
+  cd $tools_dir
 }
 dirtool=gatk*
 if [ -d $dirtool ]; then
@@ -174,64 +188,88 @@ if [ -d $dirtool ]; then
 else
   echo -e "${magenta}- Performing installation of dependency (GATK) ${white}"
   main &>> ./log.out
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} GATK did not install properly ${white}"
+  fi
 fi
 
 
 main () {
-  echo -e "${white}\n############################################## ${orange}\n- check for R installation ${white}\n##############################################${white}"
-  if R --version; then
+  if which R; then
     :
   else
     module add R
-    if R --version; then
+    if which R; then
       :
     else
-      echo -e "${white}- install R before proceeding ${white}"
-      echo -e "${white}- dependencies for R in linux: <sudo apt install libcurl4-openssl-dev> and <sudo apt install libssl-dev>"
+      echo -e "${magenta}- install R before proceeding ${white}" > /dev/tty
+      echo -e "${magenta}- dependencies for R in linux: <sudo apt install libcurl4-openssl-dev> and <sudo apt install libssl-dev> ${white}" > /dev/tty
+      exit 1
     fi
   fi
 }
+echo -e "${white}\n############################################## ${orange}\n- check for R installation ${white}\n##############################################${white}" &>> ./log.out
 main &>> ./log.out
 
 
+dirtool=R
+if [ -d $dirtool ]; then
+  cd $dirtool
+  R_dir=$(pwd)
+else
+  mkdir ./$dirtool
+  cd $dirtool
+  R_dir=$(pwd)
+fi
+
+
 main () {
-echo -e "${blue}\n############################################## \n- installing R-package: reshape2  ${blue}\n##############################################${white}"
-  mkdir -p R
-  cd ./R
+  echo -e "${blue}\n############################################## \n- installing R-package: reshape2  ${blue}\n##############################################${white}"
   R -e 'install.packages("reshape2", dependencies = TRUE, repos="http://cran.r-project.org", lib="./")'
+  cd $R_dir
 }
-dirtool=./R/reshape2
+dirtool=./reshape2
 if [ -d $dirtool ]; then
   :
 else
   echo -e "${magenta}- Performing installation of R-package: reshape2 ${white}"
   main &>> ./log.out
+  cd $R_dir
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} R-package: reshape2 did not install properly ${white}"
+  fi
 fi
 
+
 main () {
-echo -e "${blue}\n############################################## \n- installing R-package: ggplot2  ${blue}\n##############################################${white}"
-  mkdir -p R
-  cd ./R
+  echo -e "${blue}\n############################################## \n- installing R-package: ggplot2  ${blue}\n##############################################${white}"
   R -e 'install.packages("ggplot2", dependencies = TRUE, repos="http://cran.r-project.org", lib="./")'
 }
-dirtool=./R/ggplot2
+dirtool=./ggplot2
 if [ -d $dirtool ]; then
   :
 else
   echo -e "${magenta}- Performing installation of R-package: ggplot2 ${white}"
   main &>> ./log.out
+  cd $R_dir
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} R-package: ggplot2 did not install properly ${white}"
+  fi
 fi
 
+
 main () {
-echo -e "${blue}\n############################################## \n- installing R-package: CMplot  ${blue}\n##############################################${white}"
-  mkdir -p R
-  cd ./R
+  echo -e "${blue}\n############################################## \n- installing R-package: CMplot  ${blue}\n##############################################${white}"
   R -e 'install.packages("CMplot", dependencies = TRUE, repos="http://cran.r-project.org", lib="./")'
 }
-dirtool=./R/CMplot
+dirtool=./CMplot
 if [ -d $dirtool ]; then
   :
 else
   echo -e "${magenta}- Performing installation of R-package: CMplot ${white}"
   main &>> ./log.out
+  cd $R_dir
+  if [ ! -d $dirtool ]; then
+      echo -e "${magenta} R-package: CMplot did not install properly ${white}"
+  fi
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -137,7 +137,7 @@ main6 () {
   cd EMBOSS-6.6.0/
   ./configure --without-x
   make
-  cd ..
+  cd ../
   rm EMBOSS-6.6.0.tar
   cd $tools_dir
 }


### PR DESCRIPTION
- Made a variable for the tools directory that the script returns to after each installation
- Checks that directories were created for each tool after installation. Echos an error message to the terminal if they were not.
- Changes R check from "R --version" to "which R" as R --version was still giving an output message
- Reports error if R isn't installed to the terminal instead of to the log.out file
- Changes back to R directory after each R package installation