### PR TITLE
Simplify cmake command in install script to fix ngm installation issue

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ main1 () {
   cd Cibiv-NextGenMap*
   mkdir -p build/
   cd build/
-  ../../cmake-2.8.0-Linux-i386/bin/cmake ..
+  cmake ..
   make
   rm -rf ../../cmake-2.8.0-Linux-i386/
   cd $tools_dir


### PR DESCRIPTION
NGM wasn't installing properly. Simplified the cmake command and it not installs successfully.